### PR TITLE
Add variable for enabling xray tracing in api gateway

### DIFF
--- a/ecs-microservice/main.tf
+++ b/ecs-microservice/main.tf
@@ -132,18 +132,26 @@ resource "aws_api_gateway_rest_api" "api_gateway_microservice_rest_api" {
 
 resource "aws_api_gateway_deployment" "api_gateway_microservice_rest_api_deployment_v1" {
   rest_api_id = aws_api_gateway_rest_api.api_gateway_microservice_rest_api.id
-  stage_name  = "v1"
-  variables = {
-    hash = sha256(var.schema)
-  }
   lifecycle {
     create_before_destroy = true
   }
 }
 
+resource "aws_api_gateway_stage" "api_gateway_microservice_stage_v1" {
+  rest_api_id = aws_api_gateway_rest_api.api_gateway_microservice_rest_api.id
+  stage_name  = "v1_new"
+  deployment_id = aws_api_gateway_deployment.api_gateway_microservice_rest_api_deployment_v1.id
+  xray_tracing_enabled = var.api_gateway_enable_xray
+
+  variables = {
+    hash = sha256(var.schema)
+  }
+
+}
+
 resource "aws_api_gateway_base_path_mapping" "gateway_base_path_mapping" {
   api_id      = aws_api_gateway_rest_api.api_gateway_microservice_rest_api.id
-  stage_name  = aws_api_gateway_deployment.api_gateway_microservice_rest_api_deployment_v1.stage_name
+  stage_name  = aws_api_gateway_stage.api_gateway_microservice_stage_v1.stage_name
   domain_name = var.domain_name
   base_path   = var.base_path
 }

--- a/ecs-microservice/variables.tf
+++ b/ecs-microservice/variables.tf
@@ -260,3 +260,9 @@ variable "grafana_create_dashboard" {
   type        = bool
   default     = false
 }
+
+variable "api_gateway_enable_xray" {
+  description = "Used to enable xray traicng in api gateway, default false"
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION
Legger til en variabel for å styre om xray tracing er skrudd på. For å oppnå det måtte jeg ta i bruk en egen aws_api_gateway_stage ressurs istedet for å opprette denne automatisk via deployment ressursen. Dette anbefales også å gjøres i terraform docen https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/api_gateway_deployment