### PR TITLE
Use sum instead of average for counter statistics

### DIFF
--- a/ecs-microservice/grafana-templates/sqs-dashboard.tpl
+++ b/ecs-microservice/grafana-templates/sqs-dashboard.tpl
@@ -105,7 +105,7 @@
           "refId": "A",
           "region": "${region}",
           "statistics": [
-            "Average"
+            "Sum"
           ]
         }
       ],
@@ -236,7 +236,7 @@
           "refId": "A",
           "region": "${region}",
           "statistics": [
-            "Average"
+            "Sum"
           ]
         }
       ],
@@ -367,7 +367,7 @@
           "refId": "A",
           "region": "${region}",
           "statistics": [
-            "Average"
+            "Sum"
           ]
         }
       ],
@@ -1153,7 +1153,7 @@
           "refId": "A",
           "region": "${region}",
           "statistics": [
-            "Average"
+            "Sum"
           ]
         }
       ],


### PR DESCRIPTION
Metrics som representerer counters burde visualiseres utifra "sum" og ikke "average". Ved bruk av average får man gjennomsnittet per datapunkt, som bare vil bli 1 eller 0 avhengig av om det kom meldinger i intervallet eller ikke.