### PR TITLE
Fix broken reference to other module

### DIFF
--- a/api-gateway-sqs-service/main.tf
+++ b/api-gateway-sqs-service/main.tf
@@ -43,7 +43,7 @@ resource "aws_cognito_resource_server" "resource_server" {
   user_pool_id = var.user_pool_id
 }
 
-module "api-gateway-sqs-roles-duty-change" {
+module "api-gateway-sqs-roles" {
   source       = "../api-gateway-sqs-roles"
   name_prefix  = var.name_prefix
   service_name = var.service_name

--- a/api-gateway-sqs-service/outputs.tf
+++ b/api-gateway-sqs-service/outputs.tf
@@ -1,4 +1,4 @@
 output "api_gateway_sqs_role" {
   description = "The role to use when calling sqs from the api"
-  value       = aws_iam_role.api_gateway_sqs_role
+  value       = module.api-gateway-sqs-roles.api_gateway_sqs_role
 }


### PR DESCRIPTION
Oppdaget at en referanse i api-gateway-sqs service er blitt knekt når den ble delt opp i to moduler. Fikser det her