### PR TITLE
Move role module responsibility to user, add support for xray tracing

### DIFF
--- a/api-gateway-sqs-service/main.tf
+++ b/api-gateway-sqs-service/main.tf
@@ -6,18 +6,26 @@ resource "aws_api_gateway_rest_api" "api_gateway_microservice_rest_api" {
 
 resource "aws_api_gateway_deployment" "api_gateway_microservice_rest_api_deployment_v1" {
   rest_api_id = aws_api_gateway_rest_api.api_gateway_microservice_rest_api.id
-  stage_name  = "v1"
-  variables = {
-    hash = sha256(var.schema)
-  }
   lifecycle {
     create_before_destroy = true
   }
 }
 
+resource "aws_api_gateway_stage" "api_gateway_microservice_stage_v1" {
+  rest_api_id = aws_api_gateway_rest_api.api_gateway_microservice_rest_api.id
+  stage_name  = "v1_new"
+  deployment_id = aws_api_gateway_deployment.api_gateway_microservice_rest_api_deployment_v1.id
+  xray_tracing_enabled = var.api_gateway_enable_xray
+
+  variables = {
+    hash = sha256(var.schema)
+  }
+
+}
+
 resource "aws_api_gateway_base_path_mapping" "gateway_base_path_mapping" {
   api_id      = aws_api_gateway_rest_api.api_gateway_microservice_rest_api.id
-  stage_name  = aws_api_gateway_deployment.api_gateway_microservice_rest_api_deployment_v1.stage_name
+  stage_name  = aws_api_gateway_stage.api_gateway_microservice_stage_v1.stage_name
   domain_name = var.domain_name
   base_path   = var.base_path
 }
@@ -41,11 +49,4 @@ resource "aws_cognito_resource_server" "resource_server" {
   }
 
   user_pool_id = var.user_pool_id
-}
-
-module "api-gateway-sqs-roles" {
-  source       = "../api-gateway-sqs-roles"
-  name_prefix  = var.name_prefix
-  service_name = var.service_name
-  sqs_integration_arn = var.sqs_integration_arn
 }

--- a/api-gateway-sqs-service/outputs.tf
+++ b/api-gateway-sqs-service/outputs.tf
@@ -1,4 +1,0 @@
-output "api_gateway_sqs_role" {
-  description = "The role to use when calling sqs from the api"
-  value       = module.api-gateway-sqs-roles.api_gateway_sqs_role
-}

--- a/api-gateway-sqs-service/variables.tf
+++ b/api-gateway-sqs-service/variables.tf
@@ -61,3 +61,9 @@ variable "service_alarm_error_response_treshold" {
   description = "threshold for number of error responses"
   default     = 50
 }
+
+variable "api_gateway_enable_xray" {
+  description = "Used to enable xray tracing in api gateway, default false"
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION
Api gateway til sqs integrasjonen er splittet opp i to moduler pga. forskjellige bruksområder. Enn som oppretter nødvendige tilganger fra api-gateway til sqs og en som oppretter et faktisk api i apigateway.

Rollen som er output av api-gateway-sqs-roles modulen trengs som input i openapi skjemaet som brukes i den andre modulen. Det fører til en sirkulær dependency slik det er nå. Fjerner derfor api-gateway-sqs-roles herfra, så må det heller opprettes utenfor denne modulen når det skal tas i bruk (kommer PR i trafficinfo-aws med dette). 

Har i tillegg lagt til støtte for xray tracing på api-gatewayen her