### PR TITLE
Trafficinfo 487.overridable.resource.identifier

### DIFF
--- a/ecs-microservice/cognito.tf
+++ b/ecs-microservice/cognito.tf
@@ -91,6 +91,8 @@ resource "aws_ssm_parameter" "cognito-url" {
 ###########################################################
 
 locals {
+  cognito_central_resource_server_identifier_base = length(var.cognito_central_resource_server_identifier_base)>0 ? var.cognito_central_resource_server_identifier_base : var.cognito_resource_server_identifier_base
+
   # TODO
   # the code is surrounded with "try" as a workaround for
   # terraform not handling the conditional objects returned
@@ -101,7 +103,7 @@ locals {
   central_cognito_resource_server = try(var.create_resource_server ?{
     resource_server = {
       name_prefix = "${var.name_prefix}-${var.service_name}"
-      identifier = "${var.cognito_resource_server_identifier_base}/${var.service_name}"
+      identifier = "${local.cognito_central_resource_server_identifier_base}/${var.service_name}"
 
       scopes = [for key, value in var.resource_server_scopes : {
         scope_name = value.scope_name
@@ -166,7 +168,6 @@ data "aws_secretsmanager_secret_version" "microservice_client_credentials" {
 }
 
 # Store client credentials from Central Cognito in SSM so that the microservice can read it.
-# TODO probably find a more suitable name/location for the parameter.
 resource "aws_ssm_parameter" "central_client_id" {
   count = (var.cognito_central_enable && var.create_app_client) ? 1 : 0
   name      =  "/${var.name_prefix}/config/${var.service_name}/cognito.clientId"
@@ -181,7 +182,6 @@ resource "aws_ssm_parameter" "central_client_id" {
 }
 
 # Store client credentials from Central Cognito in SSM so that the microservice can read it.
-# TODO probably find a more suitable name/location for the parameter.
 resource "aws_ssm_parameter" "central_client_secret" {
   count = (var.cognito_central_enable && var.create_app_client) ? 1 : 0
   name      =  "/${var.name_prefix}/config/${var.service_name}/cognito.clientSecret"

--- a/ecs-microservice/cognito.tf
+++ b/ecs-microservice/cognito.tf
@@ -91,7 +91,7 @@ resource "aws_ssm_parameter" "cognito-url" {
 ###########################################################
 
 locals {
-  cognito_central_resource_server_identifier_base = length(var.cognito_central_resource_server_identifier_base)>0 ? var.cognito_central_resource_server_identifier_base : var.cognito_resource_server_identifier_base
+  cognito_central_resource_server_identifier = length(var.cognito_central_resource_server_identifier)>0 ? var.cognito_central_resource_server_identifier : var.cognito_resource_server_identifier_base
 
   # TODO
   # the code is surrounded with "try" as a workaround for
@@ -103,7 +103,7 @@ locals {
   central_cognito_resource_server = try(var.create_resource_server ?{
     resource_server = {
       name_prefix = "${var.name_prefix}-${var.service_name}"
-      identifier = "${local.cognito_central_resource_server_identifier_base}/${var.service_name}"
+      identifier = "${local.cognito_central_resource_server_identifier}/${var.service_name}"
 
       scopes = [for key, value in var.resource_server_scopes : {
         scope_name = value.scope_name

--- a/ecs-microservice/variables.tf
+++ b/ecs-microservice/variables.tf
@@ -290,7 +290,7 @@ variable "cognito_central_user_pool_id" {
   default     = ""
 }
 
-variable "cognito_central_resource_server_identifier_base" {
+variable "cognito_central_resource_server_identifier" {
   description = "(Optional) Override the base identifier used by resource servers created by esc-microservice module in the central cognito."
   type        = string
   default     = ""

--- a/ecs-microservice/variables.tf
+++ b/ecs-microservice/variables.tf
@@ -290,6 +290,12 @@ variable "cognito_central_user_pool_id" {
   default     = ""
 }
 
+variable "cognito_central_resource_server_identifier_base" {
+  description = "(Optional) Override the base identifier used by resource servers created by esc-microservice module in the central cognito."
+  type        = string
+  default     = ""
+}
+
 #
 ##############################################
 # Toggle X-Ray tracing for microservice in API-Gateway


### PR DESCRIPTION
This PR add a variable for overriding the resource server identifier in central cognito.
This is needed because the resource server identifier specified for the local cognito is environment specific, for example https://services.dev.trafficinfo.vydev.io/whoami/read which has DEV specified in the scope-name.
This is not usable in our micronaut code which would need to check all variants of the scopes,(dev, test, stage and prod) to verify access.

This PR makes it possible for us to specify a static resource-server-identifier that is the same in all environments, for example. https://services.trafficinfo.vydev.io/whoami/read.