### PR TITLE
Update toggle cognito_central_enable

### DIFF
--- a/ecs-microservice/cognito.tf
+++ b/ecs-microservice/cognito.tf
@@ -217,7 +217,7 @@ resource "aws_ssm_parameter" "central_cognito_url" {
 # See the configuration of the jwt token verification in the microservice application-cloud.yml
 # for how this is configured for each microservice.
 resource "aws_ssm_parameter" "central_cognito_jwks_url" {
-  count = (var.cognito_central_enable && var.create_app_client) ? 1 : 0
+  count = var.cognito_central_enable ? 1 : 0
   name  = "/${var.name_prefix}/config/${var.service_name}/jwksUrl"
   type  = "String"
 


### PR DESCRIPTION
This PR fixes a bug
If cognito_central_enable is set to true, it means that the microservice should use the central cognito instance, using the url set in jwksUrl, to verify the incoming access token. It has nothing to do with if the microservice use its own app client or not to communicate with other services. 

The `jwksUrl` points to the json document describing which keys that should be used to check the signature of the access_token in the 3rd part of the JWT payload, using the cipher as described in the 1st part of the payload.

An example url to a jwks.json file https://cognito-idp.eu-west-1.amazonaws.com/eu-west-1_Z53b9AbeT/.well-known/jwks.json