### PR TITLE
RP-70 add critical and degraded alarm levels

### DIFF
--- a/ecs-microservice/alarms-metrics.tf
+++ b/ecs-microservice/alarms-metrics.tf
@@ -1,0 +1,46 @@
+############################################################################################
+# Integrate Cloudwatch Alarms to CloudWatch Metrics via SNS topics and custom Lambda.
+############################################################################################
+# This lambda publish metrics of alarms as custom metrics in CloudWatch Metrics.
+data "aws_lambda_function" "alarms_to_metrics" {
+  function_name = "${var.name_prefix}-alarms-to-metrics"
+}
+
+# Permission to lambda to invoke from SNS degraded_alarms
+resource "aws_lambda_permission" "permission_invoke_alarms_to_metrics_to_sns_degraded_alarms" {
+  statement_id  = "AllowInvokeFromDegradedAlarmsSNS"
+  action        = "lambda:InvokeFunction"
+  function_name = data.aws_lambda_function.alarms_to_metrics.arn
+  principal     = "sns.amazonaws.com"
+  source_arn    = aws_sns_topic.degraded_alarms.arn
+}
+
+# Permission to lambda to invoke from SNS critical_alarms
+resource "aws_lambda_permission" "permission_invoke_alarms_to_metrics_to_sns_critical_alarms" {
+  statement_id  = "AllowInvokeFromCriticalAlarmsSNS"
+  action        = "lambda:InvokeFunction"
+  function_name = data.aws_lambda_function.alarms_to_metrics.arn
+  principal     = "sns.amazonaws.com"
+  source_arn    = aws_sns_topic.critical_alarms.arn
+}
+
+# Subscribe SNS Topic for Critical Alarms to lambda.
+resource "aws_sns_topic_subscription" "critical_alarms_to_metrics_subscription" {
+  endpoint  = data.aws_lambda_function.alarms_to_metrics.arn
+  protocol  = "lambda"
+  topic_arn = aws_sns_topic.critical_alarms.arn
+}
+
+# Subscribe SNS Topic for Degraded Alarms to lambda.
+resource "aws_sns_topic_subscription" "degraded_alarms_to_metrics_subscription" {
+  endpoint  = data.aws_lambda_function.alarms_to_metrics.arn
+  protocol  = "lambda"
+  topic_arn = aws_sns_topic.degraded_alarms.arn
+}
+
+# Subscribe SNS Topic for Critical Alarms to lambda.
+resource "aws_sns_topic_subscription" "subscribe_alarms_to_metrics_to_sns_critical_alarms" {
+  endpoint  = data.aws_lambda_function.alarms_to_metrics.arn
+  protocol  = "lambda"
+  topic_arn = aws_sns_topic.critical_alarms.arn
+}

--- a/ecs-microservice/alarms-pagerduty.tf
+++ b/ecs-microservice/alarms-pagerduty.tf
@@ -1,0 +1,20 @@
+############################################################################################
+# Integrate Cloudwatch Alarms to Pagerduty via SNS topics.
+############################################################################################
+# Subscribe Critical alarms to PagerDuty
+resource "aws_sns_topic_subscription" "critical_alarms_to_pagerduty" {
+  count                  = var.pager_duty_critical_endpoint == "" ? 0 : 1
+  endpoint               = var.pager_duty_critical_endpoint
+  protocol               = "https"
+  endpoint_auto_confirms = true
+  topic_arn              = aws_sns_topic.critical_alarms.arn
+}
+
+# Subscribe Degraded alarms to PagerDuty
+resource "aws_sns_topic_subscription" "degraded_alarms_to_pagerduty" {
+  count                  = var.pager_duty_degraded_endpoint == "" ? 0 : 1
+  endpoint               = var.pager_duty_degraded_endpoint
+  protocol               = "https"
+  endpoint_auto_confirms = true
+  topic_arn              = aws_sns_topic.degraded_alarms.arn
+}

--- a/ecs-microservice/alarms-slack.tf
+++ b/ecs-microservice/alarms-slack.tf
@@ -1,0 +1,46 @@
+############################################################################################
+# Integrate Cloudwatch Alarms to Slack notifications via SNS topics and custom Lambda.
+############################################################################################
+# Lambda to send notification of alarms to Slack.
+data "aws_lambda_function" "alarms_to_slack" {
+  function_name = "${var.name_prefix}-infra_alarms_to_slack"
+}
+
+# Permission to lambda to invoke from SNS degraded_alarms
+resource "aws_lambda_permission" "permission_invoke_alarms_to_slack_to_sns_degraded_alarms" {
+  statement_id  = "AllowInvokeFromDegradedAlarmsSNS"
+  action        = "lambda:InvokeFunction"
+  function_name = data.aws_lambda_function.alarms_to_slack.arn
+  principal     = "sns.amazonaws.com"
+  source_arn    = aws_sns_topic.degraded_alarms.arn
+}
+
+# Permission to lambda to invoke from SNS critical_alarms
+resource "aws_lambda_permission" "permission_invoke_alarms_to_slack_to_sns_critical_alarms" {
+  statement_id  = "AllowInvokeFromCriticalAlarmsSNS"
+  action        = "lambda:InvokeFunction"
+  function_name = data.aws_lambda_function.alarms_to_slack.arn
+  principal     = "sns.amazonaws.com"
+  source_arn    = aws_sns_topic.critical_alarms.arn
+}
+
+# Subscribe SNS Topic for Critical Alarms to lambda.
+resource "aws_sns_topic_subscription" "critical_alarms_to_slack_subscription" {
+  endpoint  = data.aws_lambda_function.alarms_to_slack.arn
+  protocol  = "lambda"
+  topic_arn = aws_sns_topic.critical_alarms.arn
+}
+
+# Subscribe SNS Topic for Degraded Alarms to lambda.
+resource "aws_sns_topic_subscription" "degraded_alarms_to_slack_subscription" {
+  endpoint  = data.aws_lambda_function.alarms_to_slack.arn
+  protocol  = "lambda"
+  topic_arn = aws_sns_topic.degraded_alarms.arn
+}
+
+# Subscribe SNS Topic for Critical Alarms to lambda.
+resource "aws_sns_topic_subscription" "subscribe_alarms_to_slack_to_sns_critical_alarms" {
+  endpoint  = data.aws_lambda_function.alarms_to_slack.arn
+  protocol  = "lambda"
+  topic_arn = aws_sns_topic.critical_alarms.arn
+}

--- a/ecs-microservice/alarms.tf
+++ b/ecs-microservice/alarms.tf
@@ -30,7 +30,7 @@ resource "aws_sns_topic_subscription" "degraded_alarms_to_pagerduty" {
 
 # Lambda to send notification of alarms to Slack.
 data "aws_lambda_function" "alarms_to_slack" {
-  function_name    = "${var.name_prefix}-infra_alarms_to_slack"
+  function_name = "${var.name_prefix}-infra_alarms_to_slack"
 }
 
 # Permission to lambda to invoke from SNS degraded_alarms
@@ -90,8 +90,8 @@ resource "aws_cloudwatch_metric_alarm" "service_unhealthy" {
   statistic         = "Average"
   alarm_description = "${var.name_prefix}-${var.service_name} service has unhealthy targets"
   tags              = var.tags
-  alarm_actions     = var.alarms_critical_sns_topic_arn
-  ok_actions        = var.alarms_critical_sns_topic_arn
+  alarm_actions     = aws_sns_topic.critical_alarms.arn
+  ok_actions        = aws_sns_topic.critical_alarms.arn
 }
 
 resource "aws_cloudwatch_metric_alarm" "high_cpu_utilization" {
@@ -109,8 +109,8 @@ resource "aws_cloudwatch_metric_alarm" "high_cpu_utilization" {
   statistic         = "Average"
   alarm_description = "${var.name_prefix}-${var.service_name} has crossed the CPU usage treshold"
   tags              = var.tags
-  alarm_actions     = var.alarms_degraded_sns_topic_arn
-  ok_actions        = var.alarms_degraded_sns_topic_arn
+  alarm_actions     = aws_sns_topic.degraded_alarms.arn
+  ok_actions        = aws_sns_topic.degraded_alarms.arn
 }
 
 resource "aws_cloudwatch_metric_alarm" "high_memory_utilization" {
@@ -128,8 +128,8 @@ resource "aws_cloudwatch_metric_alarm" "high_memory_utilization" {
   statistic         = "Average"
   alarm_description = "${var.name_prefix}-${var.service_name} has crossed the memory usage treshold"
   tags              = var.tags
-  alarm_actions     = var.alarms_degraded_sns_topic_arn
-  ok_actions        = var.alarms_degraded_sns_topic_arn
+  alarm_actions     = aws_sns_topic.degraded_alarms.arn
+  ok_actions        = aws_sns_topic.degraded_alarms.arn
 }
 
 resource "aws_cloudwatch_metric_alarm" "high_latency" {
@@ -146,8 +146,8 @@ resource "aws_cloudwatch_metric_alarm" "high_latency" {
   statistic          = "Average"
   alarm_description  = "${var.name_prefix}-${var.service_name} latency is above configured treshold"
   tags               = var.tags
-  alarm_actions      = var.alarms_degraded_sns_topic_arn
-  ok_actions         = var.alarms_degraded_sns_topic_arn
+  alarm_actions      = aws_sns_topic.degraded_alarms.arn
+  ok_actions         = aws_sns_topic.degraded_alarms.arn
   treat_missing_data = "notBreaching"
 }
 
@@ -165,8 +165,8 @@ resource "aws_cloudwatch_metric_alarm" "num_errors_service" {
   statistic          = "Average"
   alarm_description  = "${var.name_prefix}-${var.service_name} has crossed the 5xx error treshold"
   tags               = var.tags
-  alarm_actions      = var.alarms_degraded_sns_topic_arn
-  ok_actions         = var.alarms_degraded_sns_topic_arn
+  alarm_actions      = aws_sns_topic.degraded_alarms.arn
+  ok_actions         = aws_sns_topic.degraded_alarms.arn
   treat_missing_data = "notBreaching"
 }
 
@@ -184,7 +184,7 @@ resource "aws_cloudwatch_metric_alarm" "num_error_logs" {
   statistic          = "Sum"
   alarm_description  = "${var.name_prefix}-${var.service_name} has logged to many errors"
   tags               = var.tags
-  alarm_actions      = var.alarms_degraded_sns_topic_arn
-  ok_actions         = var.alarms_degraded_sns_topic_arn
+  alarm_actions      = aws_sns_topic.degraded_alarms.arn
+  ok_actions         = aws_sns_topic.degraded_alarms.arn
   treat_missing_data = "notBreaching"
 }

--- a/ecs-microservice/alarms.tf
+++ b/ecs-microservice/alarms.tf
@@ -13,8 +13,8 @@ resource "aws_cloudwatch_metric_alarm" "service_unhealthy" {
   statistic         = "Average"
   alarm_description = "${var.name_prefix}-${var.service_name} service has unhealthy targets"
   tags              = var.tags
-  alarm_actions     = var.alarms_outage_sns_topic_arn
-  ok_actions        = var.alarms_outage_sns_topic_arn
+  alarm_actions     = var.alarms_critical_sns_topic_arn
+  ok_actions        = var.alarms_critical_sns_topic_arn
 }
 
 resource "aws_cloudwatch_metric_alarm" "high_cpu_utilization" {

--- a/ecs-microservice/alarms.tf
+++ b/ecs-microservice/alarms.tf
@@ -1,3 +1,6 @@
+############################################################################################
+# Configure Alarm SNS topics for Microservice.
+############################################################################################
 # Alarm SNS topic for alarms on level DEGRADED.
 resource "aws_sns_topic" "degraded_alarms" {
   name = "${var.name_prefix}-${var.service_name}-degraded-alarms"
@@ -8,68 +11,6 @@ resource "aws_sns_topic" "degraded_alarms" {
 resource "aws_sns_topic" "critical_alarms" {
   name = "${var.name_prefix}-${var.service_name}-critical-alarms"
   tags = var.tags
-}
-
-# Subscribe Critical alarms to PagerDuty
-resource "aws_sns_topic_subscription" "critical_alarms_to_pagerduty" {
-  count                  = var.pager_duty_critical_endpoint == "" ? 0 : 1
-  endpoint               = var.pager_duty_critical_endpoint
-  protocol               = "https"
-  endpoint_auto_confirms = true
-  topic_arn              = aws_sns_topic.critical_alarms.arn
-}
-
-# Subscribe Degraded alarms to PagerDuty
-resource "aws_sns_topic_subscription" "degraded_alarms_to_pagerduty" {
-  count                  = var.pager_duty_degraded_endpoint == "" ? 0 : 1
-  endpoint               = var.pager_duty_degraded_endpoint
-  protocol               = "https"
-  endpoint_auto_confirms = true
-  topic_arn              = aws_sns_topic.degraded_alarms.arn
-}
-
-# Lambda to send notification of alarms to Slack.
-data "aws_lambda_function" "alarms_to_slack" {
-  function_name = "${var.name_prefix}-infra_alarms_to_slack"
-}
-
-# Permission to lambda to invoke from SNS degraded_alarms
-resource "aws_lambda_permission" "permission_invoke_alarms_to_slack_to_sns_degraded_alarms" {
-  statement_id  = "AllowInvokeFromDegradedAlarmsSNS"
-  action        = "lambda:InvokeFunction"
-  function_name = data.aws_lambda_function.alarms_to_slack.arn
-  principal     = "sns.amazonaws.com"
-  source_arn    = aws_sns_topic.degraded_alarms.arn
-}
-
-# Permission to lambda to invoke from SNS critical_alarms
-resource "aws_lambda_permission" "permission_invoke_alarms_to_slack_to_sns_critical_alarms" {
-  statement_id  = "AllowInvokeFromCriticalAlarmsSNS"
-  action        = "lambda:InvokeFunction"
-  function_name = data.aws_lambda_function.alarms_to_slack.arn
-  principal     = "sns.amazonaws.com"
-  source_arn    = aws_sns_topic.critical_alarms.arn
-}
-
-# Subscribe SNS Topic for Critical Alarms to lambda.
-resource "aws_sns_topic_subscription" "critical_alarms_to_slack_subscription" {
-  endpoint  = data.aws_lambda_function.alarms_to_slack.arn
-  protocol  = "lambda"
-  topic_arn = aws_sns_topic.critical_alarms.arn
-}
-
-# Subscribe SNS Topic for Degraded Alarms to lambda.
-resource "aws_sns_topic_subscription" "degraded_alarms_to_slack_subscription" {
-  endpoint  = data.aws_lambda_function.alarms_to_slack.arn
-  protocol  = "lambda"
-  topic_arn = aws_sns_topic.degraded_alarms.arn
-}
-
-# Subscribe SNS Topic for Critical Alarms to lambda.
-resource "aws_sns_topic_subscription" "subscribe_alarms_to_slack_to_sns_critical_alarms" {
-  endpoint  = data.aws_lambda_function.alarms_to_slack.arn
-  protocol  = "lambda"
-  topic_arn = aws_sns_topic.critical_alarms.arn
 }
 
 ############################################################################################

--- a/ecs-microservice/alarms.tf
+++ b/ecs-microservice/alarms.tf
@@ -13,8 +13,8 @@ resource "aws_cloudwatch_metric_alarm" "service_unhealthy" {
   statistic         = "Average"
   alarm_description = "${var.name_prefix}-${var.service_name} service has unhealthy targets"
   tags              = var.tags
-  alarm_actions     = var.alarms_sns_topic_arn
-  ok_actions        = var.alarms_sns_topic_arn
+  alarm_actions     = var.alarms_outage_sns_topic_arn
+  ok_actions        = var.alarms_outage_sns_topic_arn
 }
 
 resource "aws_cloudwatch_metric_alarm" "high_cpu_utilization" {
@@ -32,8 +32,8 @@ resource "aws_cloudwatch_metric_alarm" "high_cpu_utilization" {
   statistic         = "Average"
   alarm_description = "${var.name_prefix}-${var.service_name} has crossed the CPU usage treshold"
   tags              = var.tags
-  alarm_actions     = var.alarms_sns_topic_arn
-  ok_actions        = var.alarms_sns_topic_arn
+  alarm_actions     = var.alarms_degraded_sns_topic_arn
+  ok_actions        = var.alarms_degraded_sns_topic_arn
 }
 
 resource "aws_cloudwatch_metric_alarm" "high_memory_utilization" {
@@ -51,8 +51,8 @@ resource "aws_cloudwatch_metric_alarm" "high_memory_utilization" {
   statistic         = "Average"
   alarm_description = "${var.name_prefix}-${var.service_name} has crossed the memory usage treshold"
   tags              = var.tags
-  alarm_actions     = var.alarms_sns_topic_arn
-  ok_actions        = var.alarms_sns_topic_arn
+  alarm_actions     = var.alarms_degraded_sns_topic_arn
+  ok_actions        = var.alarms_degraded_sns_topic_arn
 }
 
 resource "aws_cloudwatch_metric_alarm" "high_latency" {
@@ -69,8 +69,8 @@ resource "aws_cloudwatch_metric_alarm" "high_latency" {
   statistic          = "Average"
   alarm_description  = "${var.name_prefix}-${var.service_name} latency is above configured treshold"
   tags               = var.tags
-  alarm_actions      = var.alarms_sns_topic_arn
-  ok_actions         = var.alarms_sns_topic_arn
+  alarm_actions      = var.alarms_degraded_sns_topic_arn
+  ok_actions         = var.alarms_degraded_sns_topic_arn
   treat_missing_data = "notBreaching"
 }
 
@@ -88,8 +88,8 @@ resource "aws_cloudwatch_metric_alarm" "num_errors_service" {
   statistic          = "Average"
   alarm_description  = "${var.name_prefix}-${var.service_name} has crossed the 5xx error treshold"
   tags               = var.tags
-  alarm_actions      = var.alarms_sns_topic_arn
-  ok_actions         = var.alarms_sns_topic_arn
+  alarm_actions      = var.alarms_degraded_sns_topic_arn
+  ok_actions         = var.alarms_degraded_sns_topic_arn
   treat_missing_data = "notBreaching"
 }
 
@@ -107,7 +107,7 @@ resource "aws_cloudwatch_metric_alarm" "num_error_logs" {
   statistic          = "Sum"
   alarm_description  = "${var.name_prefix}-${var.service_name} has logged to many errors"
   tags               = var.tags
-  alarm_actions      = var.alarms_sns_topic_arn
-  ok_actions         = var.alarms_sns_topic_arn
+  alarm_actions      = var.alarms_degraded_sns_topic_arn
+  ok_actions         = var.alarms_degraded_sns_topic_arn
   treat_missing_data = "notBreaching"
 }

--- a/ecs-microservice/alarms.tf
+++ b/ecs-microservice/alarms.tf
@@ -35,7 +35,7 @@ data "aws_lambda_function" "alarms_to_slack" {
 
 # Permission to lambda to invoke from SNS degraded_alarms
 resource "aws_lambda_permission" "permission_invoke_alarms_to_slack_to_sns_degraded_alarms" {
-  statement_id  = "AllowExecutionFromSNS"
+  statement_id  = "AllowInvokeFromDegradedAlarmsSNS"
   action        = "lambda:InvokeFunction"
   function_name = data.aws_lambda_function.alarms_to_slack.arn
   principal     = "sns.amazonaws.com"
@@ -44,7 +44,7 @@ resource "aws_lambda_permission" "permission_invoke_alarms_to_slack_to_sns_degra
 
 # Permission to lambda to invoke from SNS critical_alarms
 resource "aws_lambda_permission" "permission_invoke_alarms_to_slack_to_sns_critical_alarms" {
-  statement_id  = "AllowExecutionFromSNS"
+  statement_id  = "AllowInvokeFromCriticalAlarmsSNS"
   action        = "lambda:InvokeFunction"
   function_name = data.aws_lambda_function.alarms_to_slack.arn
   principal     = "sns.amazonaws.com"

--- a/ecs-microservice/alarms.tf
+++ b/ecs-microservice/alarms.tf
@@ -90,8 +90,8 @@ resource "aws_cloudwatch_metric_alarm" "service_unhealthy" {
   statistic         = "Average"
   alarm_description = "${var.name_prefix}-${var.service_name} service has unhealthy targets"
   tags              = var.tags
-  alarm_actions     = aws_sns_topic.critical_alarms.arn
-  ok_actions        = aws_sns_topic.critical_alarms.arn
+  alarm_actions     = [aws_sns_topic.critical_alarms.arn]
+  ok_actions        = [aws_sns_topic.critical_alarms.arn]
 }
 
 resource "aws_cloudwatch_metric_alarm" "high_cpu_utilization" {
@@ -109,8 +109,8 @@ resource "aws_cloudwatch_metric_alarm" "high_cpu_utilization" {
   statistic         = "Average"
   alarm_description = "${var.name_prefix}-${var.service_name} has crossed the CPU usage treshold"
   tags              = var.tags
-  alarm_actions     = aws_sns_topic.degraded_alarms.arn
-  ok_actions        = aws_sns_topic.degraded_alarms.arn
+  alarm_actions     = [aws_sns_topic.degraded_alarms.arn]
+  ok_actions        = [aws_sns_topic.degraded_alarms.arn]
 }
 
 resource "aws_cloudwatch_metric_alarm" "high_memory_utilization" {
@@ -128,8 +128,8 @@ resource "aws_cloudwatch_metric_alarm" "high_memory_utilization" {
   statistic         = "Average"
   alarm_description = "${var.name_prefix}-${var.service_name} has crossed the memory usage treshold"
   tags              = var.tags
-  alarm_actions     = aws_sns_topic.degraded_alarms.arn
-  ok_actions        = aws_sns_topic.degraded_alarms.arn
+  alarm_actions     = [aws_sns_topic.degraded_alarms.arn]
+  ok_actions        = [aws_sns_topic.degraded_alarms.arn]
 }
 
 resource "aws_cloudwatch_metric_alarm" "high_latency" {
@@ -146,8 +146,8 @@ resource "aws_cloudwatch_metric_alarm" "high_latency" {
   statistic          = "Average"
   alarm_description  = "${var.name_prefix}-${var.service_name} latency is above configured treshold"
   tags               = var.tags
-  alarm_actions      = aws_sns_topic.degraded_alarms.arn
-  ok_actions         = aws_sns_topic.degraded_alarms.arn
+  alarm_actions      = [aws_sns_topic.degraded_alarms.arn]
+  ok_actions         = [aws_sns_topic.degraded_alarms.arn]
   treat_missing_data = "notBreaching"
 }
 
@@ -165,8 +165,8 @@ resource "aws_cloudwatch_metric_alarm" "num_errors_service" {
   statistic          = "Average"
   alarm_description  = "${var.name_prefix}-${var.service_name} has crossed the 5xx error treshold"
   tags               = var.tags
-  alarm_actions      = aws_sns_topic.degraded_alarms.arn
-  ok_actions         = aws_sns_topic.degraded_alarms.arn
+  alarm_actions      = [aws_sns_topic.degraded_alarms.arn]
+  ok_actions         = [aws_sns_topic.degraded_alarms.arn]
   treat_missing_data = "notBreaching"
 }
 
@@ -184,7 +184,7 @@ resource "aws_cloudwatch_metric_alarm" "num_error_logs" {
   statistic          = "Sum"
   alarm_description  = "${var.name_prefix}-${var.service_name} has logged to many errors"
   tags               = var.tags
-  alarm_actions      = aws_sns_topic.degraded_alarms.arn
-  ok_actions         = aws_sns_topic.degraded_alarms.arn
+  alarm_actions      = [aws_sns_topic.degraded_alarms.arn]
+  ok_actions         = [aws_sns_topic.degraded_alarms.arn]
   treat_missing_data = "notBreaching"
 }

--- a/ecs-microservice/variables.tf
+++ b/ecs-microservice/variables.tf
@@ -15,7 +15,7 @@ variable "name_prefix" {
 
 variable "alarms_critical_sns_topic_arn" {
   type        = list(string)
-  description = "The arn(s) of the SNS topic(s) for the alarm to publish to with the alarm level CRITCAL."
+  description = "The arn(s) of the SNS topic(s) for the alarm to publish to with the alarm level CRITICAL."
   default     = []
 }
 

--- a/ecs-microservice/variables.tf
+++ b/ecs-microservice/variables.tf
@@ -13,18 +13,6 @@ variable "name_prefix" {
   description = "A prefix used for naming resources."
 }
 
-variable "alarms_critical_sns_topic_arn" {
-  type        = list(string)
-  description = "The arn(s) of the SNS topic(s) for the alarm to publish to with the alarm level CRITICAL."
-  default     = []
-}
-
-variable "alarms_degraded_sns_topic_arn" {
-  type        = list(string)
-  description = "The arn(s) of the SNS topic(s) for the alarm to publish to with the alarm level DEGRADED."
-  default     = []
-}
-
 variable "service_name" {
   description = "the microservice name"
 }
@@ -348,7 +336,6 @@ variable "cognito_central_resource_server_identifier" {
   default     = ""
 }
 
-#
 ##############################################
 # Toggle X-Ray tracing for microservice in API-Gateway
 #
@@ -357,4 +344,20 @@ variable "api_gateway_enable_xray" {
   description = "Used to enable xray tracing in api gateway, default false"
   type        = bool
   default     = false
+}
+
+##############################################
+# PagerDuty Endpoint to subscribe SNS Alarms for service.
+# Two levels of alarms, Critical and Degraded,
+##############################################
+variable "pager_duty_critical_endpoint" {
+  description = "(Optional) The PagerDuty endpoint where to subscribe CRITICAL alarms."
+  type        = string
+  default     = ""
+}
+
+variable "pager_duty_degraded_endpoint" {
+  description = "(Optional) The PagerDuty endpoint where to subscribe DEGRADED alarms."
+  type        = string
+  default     = ""
 }

--- a/ecs-microservice/variables.tf
+++ b/ecs-microservice/variables.tf
@@ -13,9 +13,15 @@ variable "name_prefix" {
   description = "A prefix used for naming resources."
 }
 
-variable "alarms_sns_topic_arn" {
+variable "alarms_outage_sns_topic_arn" {
   type        = list(string)
-  description = "The arn(s) of the SNS topic(s) for the alarm to publish to"
+  description = "The arn(s) of the SNS topic(s) for the alarm to publish to with the alarm level OUTAGE."
+  default     = []
+}
+
+variable "alarms_degraded_sns_topic_arn" {
+  type        = list(string)
+  description = "The arn(s) of the SNS topic(s) for the alarm to publish to with the alarm level DEGRADED."
   default     = []
 }
 

--- a/ecs-microservice/variables.tf
+++ b/ecs-microservice/variables.tf
@@ -13,9 +13,9 @@ variable "name_prefix" {
   description = "A prefix used for naming resources."
 }
 
-variable "alarms_outage_sns_topic_arn" {
+variable "alarms_critical_sns_topic_arn" {
   type        = list(string)
-  description = "The arn(s) of the SNS topic(s) for the alarm to publish to with the alarm level OUTAGE."
+  description = "The arn(s) of the SNS topic(s) for the alarm to publish to with the alarm level CRITCAL."
   default     = []
 }
 


### PR DESCRIPTION
# Changelog
- Introduce two levels of alarms
  - critical
  - degraded
- Remove old variable for alarm SNS topic.
- Create service unique SNS topics to subscribe pager duty endpoint .
- Add variables to provide pager duty service specific endpoints where alarsm should be subscribed to.
- Subscribe both SNS topics to Slack Notification Lambda.

_**Note that this is a major change, from the current single, globally used SNS topic where alarms from all microservices are sent, to having two SNS topics per microservice (degraded, critical) so that we can get separate SLA and service configurations in PagerDuty and Statuspage.io by service**_