### PR TITLE
Update grafana provider from 1.8.0 to 1.12.0

### DIFF
--- a/ecs-microservice/versions.tf
+++ b/ecs-microservice/versions.tf
@@ -6,7 +6,7 @@ terraform {
     }
     grafana = {
       source  = "grafana/grafana"
-      version = ">= 1.8"
+      version = ">= 1.12.0"
     }
   }
   required_version = ">= 0.12"


### PR DESCRIPTION
Grafana is being upgraded from grafana 7 to grafana 8. Version 8 removes a long deprecated endpoint that was first implemented in provider version 1.12.