### PR TITLE
NONE: Patch central cognito auth url for production

### DIFF
--- a/ecs-microservice/cognito.tf
+++ b/ecs-microservice/cognito.tf
@@ -195,6 +195,11 @@ resource "aws_ssm_parameter" "central_client_secret" {
   })
 }
 
+locals {
+  cognito_env = "${length(var.cognito_central_env) > 0 ? var.cognito_central_env : var.environment}"
+  central_cognito_url = "https://auth.${var.default_production_environment == local.cognito_env ? "" : "${local.cognito_env}."}cognito.vydev.io"
+}
+
 # SSM Parameters to configure the cognito endpoint url for microservice when requesting
 # access tokens from Cognito to communicate with other services.
 resource "aws_ssm_parameter" "central_cognito_url" {
@@ -208,7 +213,7 @@ resource "aws_ssm_parameter" "central_cognito_url" {
   })
 
   # Use default environment, or overridden cognito environment.
-  value = "https://auth.${length(var.cognito_central_env)>0 ? var.cognito_central_env : var.environment}.cognito.vydev.io"
+  value = local.central_cognito_url
   overwrite = true
 }
 

--- a/ecs-microservice/variables.tf
+++ b/ecs-microservice/variables.tf
@@ -336,6 +336,11 @@ variable "cognito_central_resource_server_identifier" {
   default     = ""
 }
 
+variable "default_production_environment" {
+  type = string
+  default = ""
+}
+
 ##############################################
 # Toggle X-Ray tracing for microservice in API-Gateway
 #


### PR DESCRIPTION
Introduces the variable "default_production_environment" with default value "prod"
determine if cognito_central_env should override environment
strip environment from central_cognito_url if inferred environment is the same as "default_production_environment"