### PR TITLE
Access logging for API-Gateway in ECS module

### DIFF
--- a/ecs-microservice/logs/access_log_format.json
+++ b/ecs-microservice/logs/access_log_format.json
@@ -1,0 +1,1 @@
+{"resourcePath":"$context.resourcePath", "httpMethod":"$context.httpMethod", "status":$context.status, "requestId":"$context.requestId", "ip": "$context.identity.sourceIp", "caller":"$context.identity.caller", "user":"$context.identity.user", "requestTime":"$context.requestTime", "protocol":"$context.protocol", "responseLength":$context.responseLength}

--- a/ecs-microservice/main.tf
+++ b/ecs-microservice/main.tf
@@ -152,6 +152,11 @@ resource "aws_api_gateway_stage" "api_gateway_microservice_stage_v1" {
   deployment_id        = aws_api_gateway_deployment.api_gateway_microservice_rest_api_deployment_v1.id
   xray_tracing_enabled = var.api_gateway_enable_xray
 
+  access_log_settings {
+    destination_arn = aws_cloudwatch_log_group.cloudwatch_log_group_api_gateway_access_log.arn
+    format          = file("${path.module}/logs/access_log_format.json")
+  }
+
   variables = {
     hash = sha256(var.schema)
   }
@@ -163,6 +168,12 @@ resource "aws_api_gateway_base_path_mapping" "gateway_base_path_mapping" {
   stage_name  = aws_api_gateway_stage.api_gateway_microservice_stage_v1.stage_name
   domain_name = var.domain_name
   base_path   = var.base_path
+}
+
+resource "aws_cloudwatch_log_group" "cloudwatch_log_group_api_gateway_access_log" {
+  name              = "API-Gateway-${var.name_prefix}-${var.service_name}-access-log"
+  tags              = var.tags
+  retention_in_days = var.access_log_retention_in_days
 }
 
 data "aws_iam_policy_document" "read_sqs_from_microservice" {

--- a/ecs-microservice/variables.tf
+++ b/ecs-microservice/variables.tf
@@ -376,3 +376,14 @@ variable "alarms_to_slack_function_name" {
   description = "The name of the lambda function that sends alarms to slack ({var.name_prefix}-infra_alarms_to_slack)"
   type = string
 }
+
+##############################################
+# Access log for API-Gateway
+#
+##############################################
+
+variable "access_log_retention_in_days" {
+  description = "The number of days to preserve the access log entries. If 0, the events in the log group will never expire"
+  type = number
+  default = 14
+}


### PR DESCRIPTION
Enables access logging for API-Gateway with default retention period for 14 days.

The access log format is slightly modified from the JSON example in the [AWS docs](https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-logging.html)