### PR TITLE
Allow multiple LBs to be attached to microservice.

### DIFF
--- a/ecs-microservice/alarms.tf
+++ b/ecs-microservice/alarms.tf
@@ -17,15 +17,16 @@ resource "aws_sns_topic" "critical_alarms" {
 # Configure Default Cloudwatch Alarms for service
 ############################################################################################
 resource "aws_cloudwatch_metric_alarm" "service_unhealthy" {
+  for_each            = var.lbs
   metric_name         = "UnHealthyHostCount"
-  alarm_name          = "${var.name_prefix}-${var.service_name}-unhealthy"
+  alarm_name          = "${var.name_prefix}-${var.service_name}-${each.key}-unhealthy"
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = 1
   threshold           = 1
   namespace           = "AWS/ApplicationELB"
   dimensions = {
-    TargetGroup  = module.ecs_fargate_microservice.target_group_arn_suffix
-    LoadBalancer = var.alb.arn_suffix
+    TargetGroup  = module.ecs_fargate_microservice.target_group_arn_suffixes[each.key]
+    LoadBalancer = each.value.arn_suffix
   }
   period            = 60
   statistic         = "Sum"

--- a/ecs-microservice/main.tf
+++ b/ecs-microservice/main.tf
@@ -49,7 +49,7 @@ module "ecs_fargate_microservice" {
 
 resource "aws_lb_listener_rule" "ecs_fargate_microservice_lb_listener" {
   for_each     = var.lbs
-  listener_arn = var.alb_http_listener.arn
+  listener_arn = each.value.listener_arn
   priority     = var.alb_priority
 
   action {

--- a/ecs-microservice/main.tf
+++ b/ecs-microservice/main.tf
@@ -12,8 +12,13 @@
 # - central cognito resource server, scopes and application client.
 #
 ##########################################################################
+locals {
+  lb_identifiers = toset([for k, lb in var.lbs : k])
+  lb_arns        = [for k, lb in var.lbs : nonsensitive(lb.arn)]
+}
+
 module "ecs_fargate_microservice" {
-  source                            = "github.com/nsbno/terraform-aws-ecs-fargate?ref=06e632c"
+  source                            = "github.com/nsbno/terraform-aws-ecs-fargate?ref=f048e0c"
   cluster_id                        = var.ecs_cluster.id
   name_prefix                       = "${var.name_prefix}-${var.service_name}"
   vpc_id                            = var.vpc.vpc_id
@@ -33,7 +38,8 @@ module "ecs_fargate_microservice" {
     interval            = var.health_check_interval
   }
 
-  lb_arn                          = var.alb.arn
+  lb_arns                         = local.lb_arns
+  target_group_identifiers        = local.lb_identifiers
   task_container_assign_public_ip = true
 
   tags          = var.tags
@@ -42,12 +48,13 @@ module "ecs_fargate_microservice" {
 
 
 resource "aws_lb_listener_rule" "ecs_fargate_microservice_lb_listener" {
+  for_each     = var.lbs
   listener_arn = var.alb_http_listener.arn
   priority     = var.alb_priority
 
   action {
     type             = "forward"
-    target_group_arn = module.ecs_fargate_microservice.target_group_arn
+    target_group_arn = module.ecs_fargate_microservice.target_group_arns[each.key]
   }
 
   condition {
@@ -62,12 +69,13 @@ resource "aws_lb_listener_rule" "ecs_fargate_microservice_lb_listener" {
 
 # Let the load balancer communicate with microservice on the service port.
 resource "aws_security_group_rule" "ecs_fargate_microservice_alb_allow" {
+  for_each                 = var.lbs
   security_group_id        = module.ecs_fargate_microservice.service_sg_id
   type                     = "ingress"
   from_port                = var.service_port
   to_port                  = var.task_container_port
   protocol                 = "tcp"
-  source_security_group_id = var.alb.security_group_id
+  source_security_group_id = each.value.security_group_id
 }
 
 resource "aws_security_group_rule" "ecs_rds_sg_allow" {

--- a/ecs-microservice/variables.tf
+++ b/ecs-microservice/variables.tf
@@ -86,12 +86,8 @@ variable "health_check_interval" {
 }
 
 variable "lbs" {
-  description = "Map of identifier to LB configuration. The key must be a string, while the value must be an object containing the keys arn, arn_suffix and security_group_id."
-  type        = map(object({ arn = string, arn_suffix = string, security_group_id = string }))
-}
-
-variable "alb_http_listener" {
-  description = "the http listener for the alb load balancer."
+  description = "Map of identifier to LB configuration. The key must be a string, while the value must be an object containing the keys arn, arn_suffix, listener_arn and security_group_id."
+  type        = map(object({ arn = string, arn_suffix = string, listener_arn = string, security_group_id = string }))
 }
 
 variable "alb_priority" {

--- a/ecs-microservice/variables.tf
+++ b/ecs-microservice/variables.tf
@@ -85,8 +85,9 @@ variable "health_check_interval" {
   type        = number
 }
 
-variable "alb" {
-  description = "the load balancer to use"
+variable "lbs" {
+  description = "Map of identifier to LB configuration. The key must be a string, while the value must be an object containing the keys arn, arn_suffix and security_group_id."
+  type        = map(object({ arn = string, arn_suffix = string, security_group_id = string }))
 }
 
 variable "alb_http_listener" {
@@ -127,7 +128,7 @@ variable "sqs_queues" {
 }
 
 variable "sqs_queues_write" {
-  type = list(string)
+  type    = list(string)
   default = []
 }
 
@@ -211,7 +212,7 @@ variable "cognito_resource_server_identifier_base" {
 
 variable "resource_server_scopes" {
   description = "Scopes to add to resource server."
-  type        = map
+  type        = map(any)
   default = {
     scope = {
       "scope_name" : "access"
@@ -281,7 +282,7 @@ variable "service_alarm_cpu_threshold" {
 # Configure Grafana Dashboard generation.
 #
 ##############################################
-variable grafana_db_instance_identifier {
+variable "grafana_db_instance_identifier" {
   description = "(Optional) Specify db instance identifier to create grafana dashboard."
   type        = string
   default     = ""
@@ -342,7 +343,7 @@ variable "cognito_central_resource_server_identifier" {
 }
 
 variable "default_production_environment" {
-  type = string
+  type    = string
   default = ""
 }
 
@@ -374,7 +375,7 @@ variable "pager_duty_degraded_endpoint" {
 
 variable "alarms_to_slack_function_name" {
   description = "The name of the lambda function that sends alarms to slack ({var.name_prefix}-infra_alarms_to_slack)"
-  type = string
+  type        = string
 }
 
 ##############################################
@@ -384,6 +385,6 @@ variable "alarms_to_slack_function_name" {
 
 variable "access_log_retention_in_days" {
   description = "The number of days to preserve the access log entries. If 0, the events in the log group will never expire"
-  type = number
-  default = 14
+  type        = number
+  default     = 14
 }


### PR DESCRIPTION
Denne PRen tar i bruk oppdatert Terraformmodul github.com/nsbno/terraform-aws-ecs-fargate?ref=f048e0c som lar en attache mer enn én target_group på en ECS service. Dette er nyttig om en f.eks. trenger å koble en ECS tjeneste til både en ekstern og en intern LB. Per nå blir samme portmapping brukt på alle targets, men det er mulig å senere utvide ytterligere for å også få til flere mappings der.

Endring i parameter: alb og alb_http_listener forsvinner, nytt parameter lbs.

I praksis:
gammel config:
```terraform
alb = {
    arn               = var.lb_arn
    arn_suffix        = var.lb_arn_suffix
    security_group_id = var.lb_security_group_id
}
alb_http_listener = {
    arn = var.lb_listener_arn
}
```

Ny config:
```terraform
lbs = {
    alb-external = {
        arn               = var.lb_arn
        arn_suffix        = var.lb_arn_suffix
        listener_arn      = var.lb_listener_arn
        security_group_id = var.lb_security_group_id
    },
    alb-internal = {
        arn               = var.internal_lb_arn
        arn_suffix        = var.internal_lb_arn_suffix
        listener_arn      = var.internal_lb_listener_arn
        security_group_id = var.internal_lb_security_group_id
    }
}
```

Oppgradering til denne versjonen av modulen vil føre til recrearion av ECS service (inkl target groups og noen ressurser til). Dette er fordi en ikke kan endre target groups i en ECS service etter den er opprettet.