### PR TITLE
Fix bug where delegated cognito config is uploaded when central cognito is disabled

### DIFF
--- a/ecs-microservice/cognito.tf
+++ b/ecs-microservice/cognito.tf
@@ -126,19 +126,19 @@ locals {
   }  : tomap(false), {})
 
   # build json config content for central cognito.
-  central_congito_config_content_json = jsonencode(
+  central_cognito_config_content_json = jsonencode(
     merge(local.central_cognito_resource_server, local.central_cognito_user_pool_client))
 }
 
 # upload delegated cognito config to S3 bucket.
 # this will trigger the delegated cognito terraform pipeline and and apply the config.
 resource "aws_s3_bucket_object" "delegated-cognito-config" {
-  count =  (length(var.cognito_central_bucket) > 0) && (var.create_resource_server || var.create_app_client) ? 1 : 0
+  count =  (var.cognito_central_enable) && (length(var.cognito_central_bucket) > 0) && (var.create_resource_server || var.create_app_client) ? 1 : 0
   bucket = var.cognito_central_bucket
   key    = "${length(var.cognito_central_env)>0 ? var.cognito_central_env : var.environment}/${local.current_account_id}/${var.name_prefix}-${var.service_name}.json"
   acl    = "bucket-owner-full-control"
 
-  content = local.central_congito_config_content_json
+  content = local.central_cognito_config_content_json
   content_type = "application/json"
 }
 


### PR DESCRIPTION
Selv om `cognito_central_enable = false` så oppretter den en json fil i bøtten for delegated cognito. Det skaper trøbbel når den prøver å opprette en app client med scopes som ikke finnes i sentral cognito (men som finnes i lokal cognito). Da ligger det en json fil i `vydev-delegated-cognito` bøtta som knekker pipelinen for andre team også.

Retter også opp i en typo