### PR TITLE
Set default prod environment. Prevents prod prefix in cognito.url variable

### DIFF
--- a/ecs-microservice/variables.tf
+++ b/ecs-microservice/variables.tf
@@ -340,7 +340,7 @@ variable "cognito_central_resource_server_identifier" {
 
 variable "default_production_environment" {
   type    = string
-  default = ""
+  default = "prod"
 }
 
 ##############################################


### PR DESCRIPTION
Ved å sette `default_production_environment` til `default = "prod"` får følgende variabel ikke prod prefix for urlen som man gjør auth mot med sentral cognito. 
```
locals {
  cognito_env = length(var.cognito_central_env) > 0 ? var.cognito_central_env : var.environment
  central_cognito_url = "https://auth.${var.default_production_environment == local.cognito_env ? "" : "${local.cognito_env}."}cognito.vydev.io"
}

resource "aws_ssm_parameter" "central_cognito_url" {
  count = (var.cognito_central_enable && var.create_app_client) ? 1 : 0
  name  = "/${var.name_prefix}/config/${var.service_name}/cognito.url"
  type  = "String"

  # store the hash as a tag to establish a dependency to the wait_for_credentials resource
  tags      = merge(var.tags, {
    config_hash: time_sleep.wait_for_credentials[0].triggers.config_hash
  })

  # Use default environment, or overridden cognito environment.
  value = local.central_cognito_url
  overwrite = true
}
```

Det sparer hvert repo fra å måtte sette `default_production_environment = "prod"` selv 