### PR TITLE
Set env variable and ephemral store

### DIFF
--- a/ecs-microservice/main.tf
+++ b/ecs-microservice/main.tf
@@ -18,7 +18,7 @@ locals {
 }
 
 module "ecs_fargate_microservice" {
-  source                            = "github.com/nsbno/terraform-aws-ecs-fargate?ref=f048e0c"
+  source                            = "github.com/nsbno/terraform-aws-ecs-fargate?ref=10f79c8"
   cluster_id                        = var.ecs_cluster.id
   name_prefix                       = "${var.name_prefix}-${var.service_name}"
   vpc_id                            = var.vpc.vpc_id
@@ -27,6 +27,7 @@ module "ecs_fargate_microservice" {
   task_container_port               = var.task_container_port
   task_definition_memory            = var.task_definition_memory
   task_definition_cpu               = var.task_definition_cpu
+  task_container_environment        = var.task_container_environment
   health_check_grace_period_seconds = var.health_check_grace_period_seconds
 
   health_check = {
@@ -44,6 +45,7 @@ module "ecs_fargate_microservice" {
 
   tags          = var.tags
   desired_count = var.desired_count
+  size_in_gib   = var.size_in_gb
 }
 
 

--- a/ecs-microservice/main.tf
+++ b/ecs-microservice/main.tf
@@ -18,7 +18,7 @@ locals {
 }
 
 module "ecs_fargate_microservice" {
-  source                            = "github.com/nsbno/terraform-aws-ecs-fargate?ref=10f79c8"
+  source                            = "github.com/nsbno/terraform-aws-ecs-fargate?ref=ac78639"
   cluster_id                        = var.ecs_cluster.id
   name_prefix                       = "${var.name_prefix}-${var.service_name}"
   vpc_id                            = var.vpc.vpc_id

--- a/ecs-microservice/main.tf
+++ b/ecs-microservice/main.tf
@@ -18,7 +18,7 @@ locals {
 }
 
 module "ecs_fargate_microservice" {
-  source                            = "github.com/nsbno/terraform-aws-ecs-fargate?ref=ecb64cc"
+  source                            = "github.com/nsbno/terraform-aws-ecs-fargate?ref=dcf5f58"
   cluster_id                        = var.ecs_cluster.id
   name_prefix                       = "${var.name_prefix}-${var.service_name}"
   vpc_id                            = var.vpc.vpc_id

--- a/ecs-microservice/main.tf
+++ b/ecs-microservice/main.tf
@@ -18,7 +18,7 @@ locals {
 }
 
 module "ecs_fargate_microservice" {
-  source                            = "github.com/nsbno/terraform-aws-ecs-fargate?ref=ac78639"
+  source                            = "github.com/nsbno/terraform-aws-ecs-fargate?ref=ecb64cc"
   cluster_id                        = var.ecs_cluster.id
   name_prefix                       = "${var.name_prefix}-${var.service_name}"
   vpc_id                            = var.vpc.vpc_id

--- a/ecs-microservice/main.tf
+++ b/ecs-microservice/main.tf
@@ -18,7 +18,7 @@ locals {
 }
 
 module "ecs_fargate_microservice" {
-  source                            = "github.com/nsbno/terraform-aws-ecs-fargate?ref=dcf5f58"
+  source                            = "github.com/nsbno/terraform-aws-ecs-fargate?ref=4aa9eb6"
   cluster_id                        = var.ecs_cluster.id
   name_prefix                       = "${var.name_prefix}-${var.service_name}"
   vpc_id                            = var.vpc.vpc_id

--- a/ecs-microservice/main.tf
+++ b/ecs-microservice/main.tf
@@ -45,7 +45,7 @@ module "ecs_fargate_microservice" {
 
   tags          = var.tags
   desired_count = var.desired_count
-  size_in_gib   = var.size_in_gb
+  size_in_gib   = var.size_in_gib
 }
 
 

--- a/ecs-microservice/variables.tf
+++ b/ecs-microservice/variables.tf
@@ -394,7 +394,7 @@ variable "task_container_environment" {
 
 ### Ephemeral storage amount
 variable "size_in_gb" {
-  description = "The total amount of ephemeral storage available, beyond the default amount"
+  description = "The total amount of ephemeral storage available, beyond the default amount. Must be between 21 and 200"
   type        = number
-  default     = 0
+  default     = null
 }

--- a/ecs-microservice/variables.tf
+++ b/ecs-microservice/variables.tf
@@ -393,7 +393,7 @@ variable "task_container_environment" {
 }
 
 ### Ephemeral storage amount
-variable "size_in_gb" {
+variable "size_in_gib" {
   description = "The total amount of ephemeral storage available, beyond the default amount. Must be between 21 and 200"
   type        = number
   default     = null

--- a/ecs-microservice/variables.tf
+++ b/ecs-microservice/variables.tf
@@ -384,3 +384,17 @@ variable "access_log_retention_in_days" {
   type        = number
   default     = 14
 }
+
+### Container environment variables
+variable "task_container_environment" {
+  description = "Environment variables to inject into the container"
+  type        = map(string)
+  default     = {}
+}
+
+### Ephemeral storage amount
+variable "size_in_gb" {
+  description = "The total amount of ephemeral storage available, beyond the default amount"
+  type        = number
+  default     = 0
+}

--- a/ecs-microservice/versions.tf
+++ b/ecs-microservice/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.21.0"
+      version = ">= 3.45.0"
     }
     grafana = {
       source  = "grafana/grafana"


### PR DESCRIPTION
Option to set environment variables for container.
Option to expand ephemeral storage beyond default 20GB.
Bump aws provider to 3.45.0