### PR TITLE
remove cognito_central_enable check on delegated-cognito-config

### DIFF
--- a/ecs-microservice/cognito.tf
+++ b/ecs-microservice/cognito.tf
@@ -130,10 +130,13 @@ locals {
     merge(local.central_cognito_resource_server, local.central_cognito_user_pool_client))
 }
 
-# upload delegated cognito config to S3 bucket.
+# Upload delegated cognito config to S3 bucket.
 # this will trigger the delegated cognito terraform pipeline and and apply the config.
+#
+# As long as a S3 bucket is set to upload delegated configuration to it will be
+# uploaded to create a resource server and/or app client if specified.
 resource "aws_s3_bucket_object" "delegated-cognito-config" {
-  count =  (var.cognito_central_enable) && (length(var.cognito_central_bucket) > 0) && (var.create_resource_server || var.create_app_client) ? 1 : 0
+  count =  length(var.cognito_central_bucket) > 0 && (var.create_resource_server || var.create_app_client) ? 1 : 0
   bucket = var.cognito_central_bucket
   key    = "${length(var.cognito_central_env)>0 ? var.cognito_central_env : var.environment}/${local.current_account_id}/${var.name_prefix}-${var.service_name}.json"
   acl    = "bucket-owner-full-control"


### PR DESCRIPTION
Will always upload s3 delegated config if s3 bucket is specified so that its possible to both create the config in central cognito, but still set it as central_cognito_enabled = false to delay start using the central cognito authorization until a later point, useful when doing a gradual roll out of central cognito config in more than one service and want to prepare a service up front instead of switching imediately.

Couple of issues though
- if creating uploading a config with scopes to other downstream dependencies that isent created yet it will break the pipeline. 
- to avoid starting the pipeline, dont set a s3 upload bucket to upload file until ready, ref https://github.com/nsbno/terraform-aws-trafficinfo/blob/master/ecs-microservice/variables.tf#L311
- if this isent a good enough, investigate posibility to create a new toggle `create_central_cognito`