### PR TITLE
Add alarm for errors logged over prolonged period

### DIFF
--- a/ecs-microservice/alarms.tf
+++ b/ecs-microservice/alarms.tf
@@ -117,14 +117,14 @@ resource "aws_cloudwatch_metric_alarm" "num_error_logs" {
   alarm_name          = "${var.name_prefix}-${var.service_name}-errors-log"
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = 1
-  threshold           = 50
+  threshold           = var.num_errors_logged_threshold
   namespace           = "${var.name_prefix}-${var.service_name}"
   dimensions = {
     level = "error"
   }
-  period             = 60
+  period             = var.num_errors_logged_period
   statistic          = "Sum"
-  alarm_description  = "${var.name_prefix}-${var.service_name} has logged to many errors"
+  alarm_description  = "${var.name_prefix}-${var.service_name} has logged too many errors"
   tags               = var.tags
   alarm_actions      = [aws_sns_topic.degraded_alarms.arn]
   ok_actions         = [aws_sns_topic.degraded_alarms.arn]

--- a/ecs-microservice/variables.tf
+++ b/ecs-microservice/variables.tf
@@ -274,6 +274,18 @@ variable "service_alarm_cpu_threshold" {
   default     = 80
 }
 
+variable "num_errors_logged_threshold" {
+  description = "Alarm threshold value. Default is 50 errors."
+  type        = number
+  default     = 50
+}
+
+variable "num_errors_logged_period" {
+  description = "Alarm period in seconds. Default is 1 minute."
+  type        = number
+  default     = 60
+}
+
 ##############################################
 # Configure Grafana Dashboard generation.
 #


### PR DESCRIPTION
To endringer
- Legger til en variabel for threshold på antall errors logget for eksisterende `errors-log`-alarm. 
- Legger til en ny optional alarm m/variabler for å fange flere enn ønsket alarmer over en lengre periode. Ønsker å kunne fange opp f.eks. _>50 errors within 30 minutes_. 