### PR TITLE
Add default to cognito_resource_server_identifier_base

### DIFF
--- a/ecs-microservice/variables.tf
+++ b/ecs-microservice/variables.tf
@@ -210,6 +210,7 @@ variable "create_resource_server" {
 
 variable "cognito_resource_server_identifier_base" {
   description = "The base identifier used by resource servers created by esc-microservice module."
+  default     = ""
 }
 
 variable "resource_server_scopes" {


### PR DESCRIPTION
Add a default to avoid lines like `cognito_resource_server_identifier_base = "" # because mandatory` after migrating to new delegated cognito