### PR TITLE
Log integrationLatency and resolved URL path to API GW access logst

### DIFF
--- a/ecs-microservice/logs/access_log_format.json
+++ b/ecs-microservice/logs/access_log_format.json
@@ -1,1 +1,15 @@
-{"resourcePath":"$context.resourcePath", "httpMethod":"$context.httpMethod", "status":$context.status, "requestId":"$context.requestId", "ip": "$context.identity.sourceIp", "caller":"$context.identity.caller", "user":"$context.identity.user", "requestTime":"$context.requestTime", "protocol":"$context.protocol", "responseLength":$context.responseLength}
+{
+  "resourcePath": "$context.resourcePath",
+  "path": "$context.path",
+  "httpMethod": "$context.httpMethod",
+  "status": "$context.status",
+  "requestId": "$context.requestId",
+  "ip": "$context.identity.sourceIp",
+  "caller": "$context.identity.caller",
+  "user": "$context.identity.user",
+  "requestTime": "$context.requestTime",
+  "protocol": "$context.protocol",
+  "responseLength": "$context.responseLength",
+  "responseLatency": "$context.responseLatency",
+  "integrationLatency": "$context.integrationLatency"
+}


### PR DESCRIPTION
Read docs here: https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-mapping-template-reference.html

Log the actual used path of a request with its path parameters. E.g. a request to the endoint `/foo/{id}` with id=123 (`/foo/123`) will now log both lines below:

```
"resourcePath": "/foo/{id}",
"path": "/foo/123",
```

Also logs the integrationLatency (The time between when API Gateway relays a request to the backend and when it receives a response from the backend).